### PR TITLE
Enhance constructorTEF by turning sort_1dim/2dim into methods

### DIFF
--- a/00_tef_core.ipynb
+++ b/00_tef_core.ipynb
@@ -29,7 +29,9 @@
     "import math\n",
     "import numpy as np\n",
     "import xarray as xr\n",
-    "import time"
+    "import time\n",
+    "\n",
+    "from pyTEF import calc"
    ]
   },
   {
@@ -62,7 +64,7 @@
     "        \"\"\"\n",
     "        if isinstance(inputFile, str):\n",
     "            try:\n",
-    "                self._read(fileName=inputFile)\n",
+    "                self._read(inputFile, **kwargs)\n",
     "            except (OSError, IOError, RunetimeError):\n",
     "                raise IOError(\"Could not read file.\")\n",
     "        elif isinstance(inputFile, xr.Dataset):\n",
@@ -95,7 +97,15 @@
     "        self.ds = self.ds.transpose(\"time\",\n",
     "                                    \"depth\",\n",
     "                                    \"lat\",\n",
-    "                                    \"lon\")"
+    "                                    \"lon\")\n",
+    "\n",
+    "    def sort_1dim(self, N=1024, minmaxrange=None):\n",
+    "        \"\"\"Transform self.transport into self.tracer-coordinates with N bins in minmaxrange.\"\"\"\n",
+    "        return calc.sort_1dim(self, N, minmaxrange)\n",
+    "\n",
+    "    def sort_2dim(self, N=(1024, 1024), minmaxrange=None, minmaxrange2=None):\n",
+    "        \"\"\"Transform self.transport into 2-dimensional self.tracer-coordinates.\"\"\"\n",
+    "        return calc.sort_2dim(self, N, minmaxrange, minmaxrange2)"
    ]
   },
   {

--- a/pyTEF/_modidx.py
+++ b/pyTEF/_modidx.py
@@ -14,5 +14,7 @@ d = { 'settings': { 'branch': 'master',
             'pyTEF.tef_core': { 'pyTEF.tef_core.constructorTEF': ('tef_core.html#constructortef', 'pyTEF/tef_core.py'),
                                 'pyTEF.tef_core.constructorTEF.__init__': ('tef_core.html#__init__', 'pyTEF/tef_core.py'),
                                 'pyTEF.tef_core.constructorTEF._read': ('tef_core.html#_read', 'pyTEF/tef_core.py'),
-                                'pyTEF.tef_core.constructorTEF._setup': ('tef_core.html#_setup', 'pyTEF/tef_core.py')},
+                                'pyTEF.tef_core.constructorTEF._setup': ('tef_core.html#_setup', 'pyTEF/tef_core.py'),
+                                'pyTEF.tef_core.constructorTEF.sort_1dim': ('tef_core.html#sort_1dim', 'pyTEF/tef_core.py'),
+                                'pyTEF.tef_core.constructorTEF.sort_2dim': ('tef_core.html#sort_2dim', 'pyTEF/tef_core.py')},
             'pyTEF.tutorial': {'pyTEF.tutorial.download_test_data': ('download_test_data.html#download_test_data', 'pyTEF/tutorial.py')}}}

--- a/pyTEF/tef_core.py
+++ b/pyTEF/tef_core.py
@@ -9,6 +9,8 @@ import numpy as np
 import xarray as xr
 import time
 
+from . import calc
+
 # %% ../00_tef_core.ipynb 3
 class constructorTEF:
     def __init__(self, inputFile, data_description, **kwargs):
@@ -32,7 +34,7 @@ class constructorTEF:
         """
         if isinstance(inputFile, str):
             try:
-                self._read(fileName=inputFile)
+                self._read(inputFile, **kwargs)
             except (OSError, IOError, RunetimeError):
                 raise IOError("Could not read file.")
         elif isinstance(inputFile, xr.Dataset):
@@ -66,3 +68,11 @@ class constructorTEF:
                                     "depth",
                                     "lat",
                                     "lon")
+
+    def sort_1dim(self, N=1024, minmaxrange=None):
+        """Transform self.transport into self.tracer-coordinates with N bins in minmaxrange."""
+        return calc.sort_1dim(self, N, minmaxrange)
+
+    def sort_2dim(self, N=(1024, 1024), minmaxrange=None, minmaxrange2=None):
+        """Transform self.transport into 2-dimensional self.tracer-coordinates."""
+        return calc.sort_2dim(self, N, minmaxrange, minmaxrange2)


### PR DESCRIPTION
By turning the functions `sort_1dim` and `sort_2dim` into methods of the class `constructorTEF`, **pyTEF feels more object-oriented.**  For an object `tef` of the class `constructorTEF`, one can now write `tef.sort_1dim()` instead of `sort_1dim(tef)`, which is more _pythonic._  Also, users need to write less import statements, since the sort functionality is now included in the `constructorTEF` class.

This change does **not** break any existing code, because the original functions still exist in the same place as before and were not modified, but using them directly can now be considered deprecated.

Also, **a bug** (presumably) **was fixed** where `kwargs` were not given from the `__init__` to the `_read` function of `constructorTEF`.